### PR TITLE
Feat : Form에 그림자 및 부드러운 테두리 추가 및 Control_File 버튼 구현

### DIFF
--- a/ForgettingCurve/Control/FileEditor/Tab/Control_File.Designer.cs
+++ b/ForgettingCurve/Control/FileEditor/Tab/Control_File.Designer.cs
@@ -35,19 +35,19 @@
             // tableLayoutPanel1
             // 
             this.tableLayoutPanel1.ColumnCount = 13;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 3F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 10F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 10F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 242F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 4F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 14F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 100F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 346F));
             this.tableLayoutPanel1.Controls.Add(this.tool_newFIle, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.tool_fileOpen, 2, 1);
             this.tableLayoutPanel1.Controls.Add(this.tool_saveFile, 3, 1);
@@ -57,10 +57,10 @@
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 3;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 3F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 3F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(895, 97);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 4F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 105F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 4F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(1279, 146);
             this.tableLayoutPanel1.TabIndex = 4;
             // 
             // tool_newFIle
@@ -72,14 +72,15 @@
             this.tool_newFIle.Font = new System.Drawing.Font("맑은 고딕", 9F);
             this.tool_newFIle.Image = ((System.Drawing.Image)(resources.GetObject("tool_newFIle.Image")));
             this.tool_newFIle.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.tool_newFIle.Location = new System.Drawing.Point(4, 4);
-            this.tool_newFIle.Margin = new System.Windows.Forms.Padding(1);
+            this.tool_newFIle.Location = new System.Drawing.Point(5, 6);
+            this.tool_newFIle.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
             this.tool_newFIle.Name = "tool_newFIle";
-            this.tool_newFIle.Size = new System.Drawing.Size(68, 68);
+            this.tool_newFIle.Size = new System.Drawing.Size(98, 101);
             this.tool_newFIle.TabIndex = 0;
             this.tool_newFIle.Text = "새로 제작";
             this.tool_newFIle.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.tool_newFIle.UseVisualStyleBackColor = false;
+            this.tool_newFIle.Click += new System.EventHandler(this.tool_newFIle_Click);
             // 
             // tool_fileOpen
             // 
@@ -90,31 +91,34 @@
             this.tool_fileOpen.Font = new System.Drawing.Font("맑은 고딕", 9F);
             this.tool_fileOpen.Image = ((System.Drawing.Image)(resources.GetObject("tool_fileOpen.Image")));
             this.tool_fileOpen.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.tool_fileOpen.Location = new System.Drawing.Point(74, 4);
-            this.tool_fileOpen.Margin = new System.Windows.Forms.Padding(1);
+            this.tool_fileOpen.Location = new System.Drawing.Point(105, 6);
+            this.tool_fileOpen.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
             this.tool_fileOpen.Name = "tool_fileOpen";
-            this.tool_fileOpen.Size = new System.Drawing.Size(68, 68);
+            this.tool_fileOpen.Size = new System.Drawing.Size(98, 101);
             this.tool_fileOpen.TabIndex = 1;
             this.tool_fileOpen.Text = "열기";
             this.tool_fileOpen.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.tool_fileOpen.UseVisualStyleBackColor = false;
+            this.tool_fileOpen.Click += new System.EventHandler(this.tool_fileOpen_Click);
             // 
             // tool_saveFile
             // 
             this.tool_saveFile.BackColor = System.Drawing.SystemColors.Control;
+            this.tool_saveFile.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tool_saveFile.FlatAppearance.BorderSize = 0;
             this.tool_saveFile.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.tool_saveFile.Font = new System.Drawing.Font("맑은 고딕", 9F);
             this.tool_saveFile.Image = ((System.Drawing.Image)(resources.GetObject("tool_saveFile.Image")));
             this.tool_saveFile.ImageAlign = System.Drawing.ContentAlignment.TopCenter;
-            this.tool_saveFile.Location = new System.Drawing.Point(144, 4);
-            this.tool_saveFile.Margin = new System.Windows.Forms.Padding(1);
+            this.tool_saveFile.Location = new System.Drawing.Point(205, 6);
+            this.tool_saveFile.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
             this.tool_saveFile.Name = "tool_saveFile";
-            this.tool_saveFile.Size = new System.Drawing.Size(68, 68);
+            this.tool_saveFile.Size = new System.Drawing.Size(98, 101);
             this.tool_saveFile.TabIndex = 2;
             this.tool_saveFile.Text = "저장";
             this.tool_saveFile.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
             this.tool_saveFile.UseVisualStyleBackColor = false;
+            this.tool_saveFile.Click += new System.EventHandler(this.tool_saveFile_Click);
             // 
             // label1
             // 
@@ -122,21 +126,22 @@
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.label1.Font = new System.Drawing.Font("맑은 고딕", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
-            this.label1.Location = new System.Drawing.Point(73, 73);
+            this.label1.Location = new System.Drawing.Point(104, 109);
             this.label1.Margin = new System.Windows.Forms.Padding(0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(70, 24);
+            this.label1.Size = new System.Drawing.Size(100, 37);
             this.label1.TabIndex = 3;
             this.label1.Text = "파일 관리";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // Control_File
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.tableLayoutPanel1);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "Control_File";
-            this.Size = new System.Drawing.Size(895, 97);
+            this.Size = new System.Drawing.Size(1279, 146);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);

--- a/ForgettingCurve/Control/FileEditor/Tab/Control_File.cs
+++ b/ForgettingCurve/Control/FileEditor/Tab/Control_File.cs
@@ -1,17 +1,49 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace ForgettingCurve.Control.FileEditor.Tab {
     public partial class Control_File : UserControl {
         public Control_File() {
             InitializeComponent();
+        }
+
+        private void tool_newFIle_Click(object sender, EventArgs e) {
+
+            if (TextEditor_Form.Instance.TB.Text != "") {
+                DialogResult dr =  MessageBox.Show("작성한 글이 초기화 됩니다.", "새로 만들기", 
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+
+                if (dr == DialogResult.Yes) {
+                    TextEditor_Form.Instance.TB.Text = "";
+                } else { }
+            }
+            else TextEditor_Form.Instance.TB.Text = "";
+        }
+
+        private void tool_fileOpen_Click(object sender, EventArgs e) {
+            TextEditor_Form.Instance.openFileDialog1.Filter = "텍스트 파일|*.txt|모든 파일|*.*";
+            TextEditor_Form.Instance.openFileDialog1.FilterIndex = 0;
+            TextEditor_Form.Instance.openFileDialog1.InitialDirectory 
+                = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            TextEditor_Form.Instance.openFileDialog1.FileName = "";
+
+            if (TextEditor_Form.Instance.openFileDialog1.ShowDialog() == DialogResult.OK) {
+                TextEditor_Form.Instance.windows_text.Text = TextEditor_Form.Instance.openFileDialog1.FileName + " - 텍스트 편집기";
+            }
+        }
+
+        private void tool_saveFile_Click(object sender, EventArgs e) {
+            TextEditor_Form.Instance.saveFileDialog1.AddExtension = true;
+            TextEditor_Form.Instance.saveFileDialog1.DefaultExt = "txt";
+            TextEditor_Form.Instance.saveFileDialog1.OverwritePrompt = true;
+            TextEditor_Form.Instance.saveFileDialog1.FileName = "";
+            TextEditor_Form.Instance.saveFileDialog1.InitialDirectory
+                = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            TextEditor_Form.Instance.saveFileDialog1.FileName = "";
+
+            if (TextEditor_Form.Instance.saveFileDialog1.ShowDialog() == DialogResult.OK) {
+                TextEditor_Form.Instance.windows_text.Text = TextEditor_Form.Instance.saveFileDialog1.FileName + " - 텍스트 편집기";
+            }
         }
     }
 }

--- a/ForgettingCurve/Control/FileEditor/Tab/Control_File.resx
+++ b/ForgettingCurve/Control/FileEditor/Tab/Control_File.resx
@@ -121,7 +121,7 @@
   <data name="tool_newFIle.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADIAAAAoCAYAAAC8cqlMAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EAAACxABrSO9dQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
+        DwAACw8BkvkDpQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
         YyOMjTA2wtgIYyOME5LR/8UwTtjn+jF3px7DGNDRfRmMAR3dl8EY0NF9GYwBHd2XwRjQ0f3KefTGwhjQ
         0d2h0TsLY0BHd+JGby2MAR3dz9zo7SWMAR3dlRu9vYUxoKP7wY3eTsEY0NF950Zvp2EM6O7uOnr7F4wB
         3dVNd373CMaAznWdvolgDOio6fS7GMaATpu7vQZjQKeNfr8K4wOzo29fgbERxkYYG2FshLERxkYYG2Fs
@@ -131,7 +131,7 @@
   <data name="tool_fileOpen.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADIAAAAoCAYAAAC8cqlMAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EAAACxABrSO9dQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
+        DwAACw8BkvkDpQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
         YyOMjTA2wtgIYyOME5LR/8UwTtjn+jF3px7DGNDRfRmMAR3dl8EY0NF9GYwBHd2XwRjQ0f3KefTGwhjQ
         0d2h0TsLY0BHd+JGby2MAR3dz9zo7SWMAR3dlRu9vYUxoKP7wY3eTsEY0NF950Zvp2EM6O7uOnr7F4wB
         3dVNd373CMaAznWdvolgDOio6fS7GMaATpu7vQZjQKeNfr8K4wOzo29fgbERxkYYG2FshLERxkYYG2Fs
@@ -141,7 +141,7 @@
   <data name="tool_saveFile.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADIAAAAoCAYAAAC8cqlMAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        EAAACxABrSO9dQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
+        DwAACw8BkvkDpQAAAOpJREFUaEPdzEEKhEAUA1Hvf+keXAhBKtpj7EUMPBjqt7ONMT4BYyOMjTA2wtgI
         YyOMjTA2wtgIYyOME5LR/8UwTtjn+jF3px7DGNDRfRmMAR3dl8EY0NF9GYwBHd2XwRjQ0f3KefTGwhjQ
         0d2h0TsLY0BHd+JGby2MAR3dz9zo7SWMAR3dlRu9vYUxoKP7wY3eTsEY0NF950Zvp2EM6O7uOnr7F4wB
         3dVNd373CMaAznWdvolgDOio6fS7GMaATpu7vQZjQKeNfr8K4wOzo29fgbERxkYYG2FshLERxkYYG2Fs

--- a/ForgettingCurve/Control/FileEditor/TextEditor.Designer.cs
+++ b/ForgettingCurve/Control/FileEditor/TextEditor.Designer.cs
@@ -42,6 +42,8 @@
             this.tab_file_Button = new System.Windows.Forms.Button();
             this.tab_toolBox = new System.Windows.Forms.Panel();
             this.control_Panel = new ForgettingCurve.Control.FileEditor.Tab.Control_File();
+            this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
+            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.windows_panel.SuspendLayout();
             this.tableLayoutPanel.SuspendLayout();
             this.tab_view_Color.SuspendLayout();
@@ -63,7 +65,7 @@
             this.windows_panel.Location = new System.Drawing.Point(0, 0);
             this.windows_panel.Margin = new System.Windows.Forms.Padding(0);
             this.windows_panel.Name = "windows_panel";
-            this.windows_panel.Size = new System.Drawing.Size(895, 46);
+            this.windows_panel.Size = new System.Drawing.Size(1279, 69);
             this.windows_panel.TabIndex = 0;
             // 
             // LOGO
@@ -71,13 +73,13 @@
             this.LOGO.Dock = System.Windows.Forms.DockStyle.Left;
             this.LOGO.FlatAppearance.BorderSize = 0;
             this.LOGO.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.LOGO.Font = new System.Drawing.Font("넥슨Lv1고딕 OTF Light", 9F);
+            this.LOGO.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F);
             this.LOGO.ForeColor = System.Drawing.SystemColors.Control;
             this.LOGO.Image = ((System.Drawing.Image)(resources.GetObject("LOGO.Image")));
             this.LOGO.Location = new System.Drawing.Point(0, 0);
             this.LOGO.Margin = new System.Windows.Forms.Padding(0);
             this.LOGO.Name = "LOGO";
-            this.LOGO.Size = new System.Drawing.Size(50, 46);
+            this.LOGO.Size = new System.Drawing.Size(71, 69);
             this.LOGO.TabIndex = 4;
             this.LOGO.UseVisualStyleBackColor = true;
             // 
@@ -87,10 +89,10 @@
             this.windows_text.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.windows_text.Font = new System.Drawing.Font("맑은 고딕", 10F);
             this.windows_text.ForeColor = System.Drawing.SystemColors.HighlightText;
-            this.windows_text.Location = new System.Drawing.Point(50, 3);
+            this.windows_text.Location = new System.Drawing.Point(71, 4);
             this.windows_text.Margin = new System.Windows.Forms.Padding(0);
             this.windows_text.Name = "windows_text";
-            this.windows_text.Size = new System.Drawing.Size(695, 40);
+            this.windows_text.Size = new System.Drawing.Size(993, 60);
             this.windows_text.TabIndex = 3;
             this.windows_text.Text = "텍스트 편집기 - 새 텍스트";
             this.windows_text.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -104,10 +106,10 @@
             this.hide_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.hide_button.Font = new System.Drawing.Font("Webdings", 12F);
             this.hide_button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            this.hide_button.Location = new System.Drawing.Point(745, 0);
+            this.hide_button.Location = new System.Drawing.Point(1066, 0);
             this.hide_button.Margin = new System.Windows.Forms.Padding(0);
             this.hide_button.Name = "hide_button";
-            this.hide_button.Size = new System.Drawing.Size(50, 46);
+            this.hide_button.Size = new System.Drawing.Size(71, 69);
             this.hide_button.TabIndex = 2;
             this.hide_button.Text = "0";
             this.hide_button.UseVisualStyleBackColor = true;
@@ -121,10 +123,10 @@
             this.windows_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.windows_button.Font = new System.Drawing.Font("Webdings", 12F);
             this.windows_button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            this.windows_button.Location = new System.Drawing.Point(795, 0);
+            this.windows_button.Location = new System.Drawing.Point(1137, 0);
             this.windows_button.Margin = new System.Windows.Forms.Padding(0);
             this.windows_button.Name = "windows_button";
-            this.windows_button.Size = new System.Drawing.Size(50, 46);
+            this.windows_button.Size = new System.Drawing.Size(71, 69);
             this.windows_button.TabIndex = 1;
             this.windows_button.Text = "1";
             this.windows_button.UseVisualStyleBackColor = true;
@@ -138,10 +140,10 @@
             this.close_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.close_button.Font = new System.Drawing.Font("Webdings", 12F);
             this.close_button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            this.close_button.Location = new System.Drawing.Point(845, 0);
+            this.close_button.Location = new System.Drawing.Point(1208, 0);
             this.close_button.Margin = new System.Windows.Forms.Padding(0);
             this.close_button.Name = "close_button";
-            this.close_button.Size = new System.Drawing.Size(50, 46);
+            this.close_button.Size = new System.Drawing.Size(71, 69);
             this.close_button.TabIndex = 0;
             this.close_button.Text = "r";
             this.close_button.UseVisualStyleBackColor = true;
@@ -151,39 +153,39 @@
             // 
             this.textBox.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.textBox.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.textBox.Location = new System.Drawing.Point(0, 176);
+            this.textBox.Location = new System.Drawing.Point(0, 263);
             this.textBox.Margin = new System.Windows.Forms.Padding(0);
             this.textBox.Multiline = true;
             this.textBox.Name = "textBox";
-            this.textBox.Size = new System.Drawing.Size(895, 658);
+            this.textBox.Size = new System.Drawing.Size(1279, 987);
             this.textBox.TabIndex = 1;
             // 
             // tableLayoutPanel
             // 
             this.tableLayoutPanel.BackColor = System.Drawing.SystemColors.ButtonHighlight;
             this.tableLayoutPanel.ColumnCount = 10;
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 2F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 2F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 2F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 2F));
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 60F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 3F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 3F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 3F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 3F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 86F));
             this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 29F));
             this.tableLayoutPanel.Controls.Add(this.tab_view_Color, 6, 0);
             this.tableLayoutPanel.Controls.Add(this.tab_design_Color, 4, 0);
             this.tableLayoutPanel.Controls.Add(this.tab_edit_Color, 2, 0);
             this.tableLayoutPanel.Controls.Add(this.tab_file_Color, 0, 0);
             this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tableLayoutPanel.Location = new System.Drawing.Point(0, 46);
+            this.tableLayoutPanel.Location = new System.Drawing.Point(0, 69);
             this.tableLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel.Name = "tableLayoutPanel";
             this.tableLayoutPanel.RowCount = 1;
             this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel.Size = new System.Drawing.Size(895, 33);
+            this.tableLayoutPanel.Size = new System.Drawing.Size(1279, 50);
             this.tableLayoutPanel.TabIndex = 2;
             // 
             // tab_view_Color
@@ -191,11 +193,11 @@
             this.tab_view_Color.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.tab_view_Color.Controls.Add(this.tab_view_Button);
             this.tab_view_Color.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tab_view_Color.Location = new System.Drawing.Point(186, 0);
+            this.tab_view_Color.Location = new System.Drawing.Point(267, 0);
             this.tab_view_Color.Margin = new System.Windows.Forms.Padding(0);
             this.tab_view_Color.Name = "tab_view_Color";
-            this.tab_view_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
-            this.tab_view_Color.Size = new System.Drawing.Size(60, 33);
+            this.tab_view_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.tab_view_Color.Size = new System.Drawing.Size(86, 50);
             this.tab_view_Color.TabIndex = 3;
             // 
             // tab_view_Button
@@ -208,7 +210,7 @@
             this.tab_view_Button.Location = new System.Drawing.Point(0, 0);
             this.tab_view_Button.Margin = new System.Windows.Forms.Padding(0);
             this.tab_view_Button.Name = "tab_view_Button";
-            this.tab_view_Button.Size = new System.Drawing.Size(60, 28);
+            this.tab_view_Button.Size = new System.Drawing.Size(86, 42);
             this.tab_view_Button.TabIndex = 0;
             this.tab_view_Button.Text = "보기";
             this.tab_view_Button.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -220,11 +222,11 @@
             this.tab_design_Color.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.tab_design_Color.Controls.Add(this.tab_design_Button);
             this.tab_design_Color.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tab_design_Color.Location = new System.Drawing.Point(124, 0);
+            this.tab_design_Color.Location = new System.Drawing.Point(178, 0);
             this.tab_design_Color.Margin = new System.Windows.Forms.Padding(0);
             this.tab_design_Color.Name = "tab_design_Color";
-            this.tab_design_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
-            this.tab_design_Color.Size = new System.Drawing.Size(60, 33);
+            this.tab_design_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.tab_design_Color.Size = new System.Drawing.Size(86, 50);
             this.tab_design_Color.TabIndex = 2;
             // 
             // tab_design_Button
@@ -237,7 +239,7 @@
             this.tab_design_Button.Location = new System.Drawing.Point(0, 0);
             this.tab_design_Button.Margin = new System.Windows.Forms.Padding(0);
             this.tab_design_Button.Name = "tab_design_Button";
-            this.tab_design_Button.Size = new System.Drawing.Size(60, 28);
+            this.tab_design_Button.Size = new System.Drawing.Size(86, 42);
             this.tab_design_Button.TabIndex = 0;
             this.tab_design_Button.Text = "서식";
             this.tab_design_Button.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -249,11 +251,11 @@
             this.tab_edit_Color.BackColor = System.Drawing.SystemColors.ButtonFace;
             this.tab_edit_Color.Controls.Add(this.tab_edit_Button);
             this.tab_edit_Color.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tab_edit_Color.Location = new System.Drawing.Point(62, 0);
+            this.tab_edit_Color.Location = new System.Drawing.Point(89, 0);
             this.tab_edit_Color.Margin = new System.Windows.Forms.Padding(0);
             this.tab_edit_Color.Name = "tab_edit_Color";
-            this.tab_edit_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
-            this.tab_edit_Color.Size = new System.Drawing.Size(60, 33);
+            this.tab_edit_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.tab_edit_Color.Size = new System.Drawing.Size(86, 50);
             this.tab_edit_Color.TabIndex = 1;
             // 
             // tab_edit_Button
@@ -266,7 +268,7 @@
             this.tab_edit_Button.Location = new System.Drawing.Point(0, 0);
             this.tab_edit_Button.Margin = new System.Windows.Forms.Padding(0);
             this.tab_edit_Button.Name = "tab_edit_Button";
-            this.tab_edit_Button.Size = new System.Drawing.Size(60, 28);
+            this.tab_edit_Button.Size = new System.Drawing.Size(86, 42);
             this.tab_edit_Button.TabIndex = 0;
             this.tab_edit_Button.Text = "편집";
             this.tab_edit_Button.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -281,8 +283,8 @@
             this.tab_file_Color.Location = new System.Drawing.Point(0, 0);
             this.tab_file_Color.Margin = new System.Windows.Forms.Padding(0);
             this.tab_file_Color.Name = "tab_file_Color";
-            this.tab_file_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
-            this.tab_file_Color.Size = new System.Drawing.Size(60, 33);
+            this.tab_file_Color.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
+            this.tab_file_Color.Size = new System.Drawing.Size(86, 50);
             this.tab_file_Color.TabIndex = 0;
             // 
             // tab_file_Button
@@ -295,7 +297,7 @@
             this.tab_file_Button.Location = new System.Drawing.Point(0, 0);
             this.tab_file_Button.Margin = new System.Windows.Forms.Padding(0);
             this.tab_file_Button.Name = "tab_file_Button";
-            this.tab_file_Button.Size = new System.Drawing.Size(60, 28);
+            this.tab_file_Button.Size = new System.Drawing.Size(86, 42);
             this.tab_file_Button.TabIndex = 0;
             this.tab_file_Button.Text = "파일";
             this.tab_file_Button.TextAlign = System.Drawing.ContentAlignment.BottomCenter;
@@ -306,32 +308,40 @@
             // 
             this.tab_toolBox.Controls.Add(this.control_Panel);
             this.tab_toolBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tab_toolBox.Location = new System.Drawing.Point(0, 79);
+            this.tab_toolBox.Location = new System.Drawing.Point(0, 119);
+            this.tab_toolBox.Margin = new System.Windows.Forms.Padding(4);
             this.tab_toolBox.Name = "tab_toolBox";
-            this.tab_toolBox.Size = new System.Drawing.Size(895, 97);
+            this.tab_toolBox.Size = new System.Drawing.Size(1279, 144);
             this.tab_toolBox.TabIndex = 3;
             // 
             // control_Panel
             // 
             this.control_Panel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.control_Panel.Location = new System.Drawing.Point(0, 0);
+            this.control_Panel.Margin = new System.Windows.Forms.Padding(6);
             this.control_Panel.Name = "control_Panel";
-            this.control_Panel.Size = new System.Drawing.Size(895, 97);
+            this.control_Panel.Size = new System.Drawing.Size(1279, 144);
             this.control_Panel.TabIndex = 0;
+            // 
+            // openFileDialog1
+            // 
+            this.openFileDialog1.FileName = "openFileDialog1";
             // 
             // TextEditor_Form
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.ClientSize = new System.Drawing.Size(895, 834);
+            this.ClientSize = new System.Drawing.Size(1279, 1250);
             this.Controls.Add(this.tab_toolBox);
             this.Controls.Add(this.tableLayoutPanel);
             this.Controls.Add(this.windows_panel);
             this.Controls.Add(this.textBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.ImeMode = System.Windows.Forms.ImeMode.On;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "TextEditor_Form";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "TextEditor";
             this.Load += new System.EventHandler(this.TextEditor_Form_Load);
             this.windows_panel.ResumeLayout(false);
@@ -349,7 +359,7 @@
         #endregion
         private System.Windows.Forms.Panel windows_panel;
         private System.Windows.Forms.Button LOGO;
-        private System.Windows.Forms.Label windows_text;
+        public System.Windows.Forms.Label windows_text;
         private System.Windows.Forms.Button hide_button;
         private System.Windows.Forms.Button windows_button;
         private System.Windows.Forms.Button close_button;
@@ -365,5 +375,7 @@
         private System.Windows.Forms.Panel tab_edit_Color;
         private System.Windows.Forms.Button tab_edit_Button;
         private Tab.Control_File control_Panel;
+        public System.Windows.Forms.SaveFileDialog saveFileDialog1;
+        public System.Windows.Forms.OpenFileDialog openFileDialog1;
     }
 }

--- a/ForgettingCurve/Control/FileEditor/TextEditor.cs
+++ b/ForgettingCurve/Control/FileEditor/TextEditor.cs
@@ -1,23 +1,19 @@
 ﻿using ForgettingCurve.Control.FileEditor.Tab;
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Forms;
 
 namespace ForgettingCurve.Control.FileEditor {
     public partial class TextEditor_Form : Form {
         public TextEditor_Form() {
             InitializeComponent();
+            // 윈도우 폼에 그림자를 추가하는 코드
+            (new Core.DropShadow()).ApplyShadows(this);
         }
 
         #region ◆ 윈도우 dll 선언 부분 (Sub 부분)
+
         /* Form의 설정 중 FormBorderStyle(폼 테두리 스타일)을 None(없음)으로 설정 시 폼의 테두리가 없어져서
          * 드래그를 통해 폼의 위치를 옮길 수가 없는데 윈도우의 내장 dll파일을 이용하여 테두리가 없어도
          * 폼의 아무 부분을 클릭하고 드래그하면 이동 시킬 수 있는 형식으로 만들기 위해
@@ -34,7 +30,6 @@ namespace ForgettingCurve.Control.FileEditor {
             ReleaseCapture();
             SendMessage(this.Handle, WM_NCLBUTTONDOWN, HT_CAPTION, 0);
         }
-
         #endregion
 
         #region ◆ 외부 코드 접근 영역
@@ -70,7 +65,7 @@ namespace ForgettingCurve.Control.FileEditor {
         private bool normalSize = true;
 
         private void close_button_Click(object sender, EventArgs e) {
-            this.Close();
+            this.Hide();
         }
 
         private void windows_button_Click(object sender, EventArgs e) {

--- a/ForgettingCurve/Control/FileEditor/TextEditor.resx
+++ b/ForgettingCurve/Control/FileEditor/TextEditor.resx
@@ -128,4 +128,10 @@
         hLERxj5j+wF9P+9UWveDOgAAAABJRU5ErkJggg==
 </value>
   </data>
+  <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>209, 17</value>
+  </metadata>
 </root>

--- a/ForgettingCurve/DropShadowWindows.cs
+++ b/ForgettingCurve/DropShadowWindows.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+/* 
+ * 본 코드는 [테두리가 없는 윈도우 창] 에 그림자를 표현해주는 코드. (즉, FormborderStyle : None인 경우)
+ * FormBorderStyle이 None일 경우 윈도우의 테두리가 없어지는데, 그와 동시에 원래 있던 그림자도 함께 사라지기 때문에
+ * 본 코드의 ApplyShadows()를 이용해서 없어진 윈도우 창에 그림자 효과를 줄 수 있게됨.
+ * 
+ * 제작 중인 코드에 (new Core.DropShadow()).ApplyShadows(this); 로 사용함.
+ */
+
+namespace Core {
+    public class DropShadow {
+        #region Shadowing
+
+        #region Fields
+
+        private const int WM_NCHITTEST = 0x84;
+        private const int WS_MINIMIZEBOX = 0x20000;
+        private const int HTCLIENT = 0x1;
+        private const int HTCAPTION = 0x2;
+        private const int CS_DBLCLKS = 0x8;
+        private const int CS_DROPSHADOW = 0x00020000;
+        private const int WM_NCPAINT = 0x0085;
+        private const int WM_ACTIVATEAPP = 0x001C;
+
+        #endregion
+
+        #region Structures
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct MARGINS {
+            public int leftWidth;
+            public int rightWidth;
+            public int topHeight;
+            public int bottomHeight;
+        }
+
+        #endregion
+
+        #region Methods
+
+        #region Public
+
+        [DllImport("dwmapi.dll")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static extern int DwmExtendFrameIntoClientArea(IntPtr hWnd, ref MARGINS pMarInset);
+
+        [DllImport("dwmapi.dll")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+
+        #endregion
+
+        #region Overrides
+
+        /// <summary>
+        /// 그림자를 표시합니다.
+        /// </summary>
+        /// <param name="form"> 현재 Form </param>
+        public void ApplyShadows(Form form) {
+            var v = 2;
+
+            DwmSetWindowAttribute(form.Handle, 2, ref v, 4);
+
+            MARGINS margins = new MARGINS() {
+                bottomHeight = 1,
+                leftWidth = 1,
+                rightWidth = 1,
+                topHeight = 1
+            };
+            
+            DwmExtendFrameIntoClientArea(form.Handle, ref margins);
+        }
+
+        #endregion
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/ForgettingCurve/ForgettingCurve.csproj
+++ b/ForgettingCurve/ForgettingCurve.csproj
@@ -47,81 +47,21 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNetCore.Cryptography.Internal.9.0.0\lib\net462\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.AspNetCore.Cryptography.KeyDerivation.9.0.0\lib\net462\Microsoft.AspNetCore.Cryptography.KeyDerivation.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.9.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Extensions.FileProviders.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Extensions.FileSystemGlobbing.6.0.0\lib\net461\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Extensions.Primitives.6.0.0\lib\net461\Microsoft.Extensions.Primitives.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Commands, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Commands.6.14.0\lib\net472\NuGet.Commands.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Common, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Common.6.14.0\lib\net472\NuGet.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Configuration.6.14.0\lib\net472\NuGet.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Credentials, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Credentials.6.14.0\lib\net472\NuGet.Credentials.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.DependencyResolver.Core.6.14.0\lib\net472\NuGet.DependencyResolver.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Frameworks, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Frameworks.6.14.0\lib\net472\NuGet.Frameworks.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.LibraryModel.6.14.0\lib\net472\NuGet.LibraryModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Packaging.6.14.0\lib\net472\NuGet.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.ProjectModel.6.14.0\lib\net472\NuGet.ProjectModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Protocol, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Protocol.6.14.0\lib\net472\NuGet.Protocol.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=6.14.0.116, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\NuGet.Versioning.6.14.0\lib\net472\NuGet.Versioning.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="QRCoder, Version=1.6.0.0, Culture=neutral, PublicKeyToken=c4ed5b9ae8358a28, processorArchitecture=MSIL">
-      <HintPath>packages\QRCoder.1.6.0\lib\net40\QRCoder.dll</HintPath>
-    </Reference>
     <Reference Include="System">
       <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\System.dll</HintPath>
     </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Collections.Immutable.9.0.0\lib\net462\System.Collections.Immutable.dll</HintPath>
-    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.IO.Pipelines, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.IO.Pipelines.9.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
-    </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
@@ -136,9 +76,6 @@
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Text.Encodings.Web, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.9.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
     <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
@@ -230,6 +167,7 @@
     <Compile Include="Control\FileEditor\TextEditor.Designer.cs">
       <DependentUpon>TextEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="DropShadowWindows.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -338,10 +276,4 @@
     <None Include="Resources\EditorLogo.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>이 프로젝트는 이 컴퓨터에 없는 NuGet 패키지를 참조합니다. 해당 패키지를 다운로드하려면 NuGet 패키지 복원을 사용하십시오. 자세한 내용은 http://go.microsoft.com/fwlink/?LinkID=322105를 참조하십시오. 누락된 파일은 {0}입니다.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\BlazorDownloadFile.2.4.0.2\build\BlazorDownloadFile.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BlazorDownloadFile.2.4.0.2\build\BlazorDownloadFile.props'))" />
-  </Target>
 </Project>

--- a/ForgettingCurve/MainForm.Designer.cs
+++ b/ForgettingCurve/MainForm.Designer.cs
@@ -38,19 +38,24 @@
             this.file_Text = new System.Windows.Forms.Label();
             this.share_Button = new System.Windows.Forms.Button();
             this.FileOpen_Button = new System.Windows.Forms.Button();
-            this.close_Button = new System.Windows.Forms.Button();
             this.setting_Button = new System.Windows.Forms.Button();
+            this.windows_panel = new System.Windows.Forms.Panel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.hide_button = new System.Windows.Forms.Button();
+            this.windows_Button = new System.Windows.Forms.Button();
+            this.close_Button = new System.Windows.Forms.Button();
             this.Panel.SuspendLayout();
+            this.windows_panel.SuspendLayout();
             this.SuspendLayout();
             // 
             // main_Logo
             // 
             this.main_Logo.AutoSize = true;
-            this.main_Logo.Font = new System.Drawing.Font("Microsoft Sans Serif", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.main_Logo.Font = new System.Drawing.Font("맑은 고딕", 15.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.main_Logo.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
-            this.main_Logo.Location = new System.Drawing.Point(31, 60);
+            this.main_Logo.Location = new System.Drawing.Point(37, 100);
             this.main_Logo.Name = "main_Logo";
-            this.main_Logo.Size = new System.Drawing.Size(363, 37);
+            this.main_Logo.Size = new System.Drawing.Size(333, 45);
             this.main_Logo.TabIndex = 12;
             this.main_Logo.Text = "FORGETTING CURVE";
             // 
@@ -61,7 +66,7 @@
             this.user_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.user_Button.Font = new System.Drawing.Font("굴림", 8F);
             this.user_Button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            this.user_Button.Location = new System.Drawing.Point(1744, 52);
+            this.user_Button.Location = new System.Drawing.Point(1740, 96);
             this.user_Button.Name = "user_Button";
             this.user_Button.Size = new System.Drawing.Size(50, 50);
             this.user_Button.TabIndex = 12;
@@ -83,10 +88,10 @@
             this.Panel.Controls.Add(this.share_Button);
             this.Panel.Controls.Add(this.FileOpen_Button);
             this.Panel.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.Panel.Location = new System.Drawing.Point(0, 118);
+            this.Panel.Location = new System.Drawing.Point(0, 163);
             this.Panel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Panel.Name = "Panel";
-            this.Panel.Size = new System.Drawing.Size(1806, 942);
+            this.Panel.Size = new System.Drawing.Size(1806, 897);
             this.Panel.TabIndex = 0;
             // 
             // recentFile_Text
@@ -105,7 +110,7 @@
             // 
             this.calender_Button.FlatAppearance.BorderSize = 0;
             this.calender_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.calender_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.calender_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.calender_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.calender_Button.Location = new System.Drawing.Point(33, 280);
             this.calender_Button.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
@@ -122,7 +127,7 @@
             // 
             this.home_Button.FlatAppearance.BorderSize = 0;
             this.home_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.home_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.home_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.home_Button.Image = global::ForgettingCurve.Properties.Resources.Home_Icon;
             this.home_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.home_Button.Location = new System.Drawing.Point(33, 148);
@@ -134,6 +139,7 @@
             this.home_Button.Text = "        HOME";
             this.home_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.home_Button.UseVisualStyleBackColor = true;
+            this.home_Button.Click += new System.EventHandler(this.home_Button_Click);
             // 
             // normal_Text
             // 
@@ -161,7 +167,7 @@
             // 
             this.trashBin_Button.FlatAppearance.BorderSize = 0;
             this.trashBin_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.trashBin_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.trashBin_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.trashBin_Button.Image = global::ForgettingCurve.Properties.Resources.Trash;
             this.trashBin_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.trashBin_Button.Location = new System.Drawing.Point(33, 496);
@@ -178,7 +184,7 @@
             // 
             this.newFile_Button.FlatAppearance.BorderSize = 0;
             this.newFile_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.newFile_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.newFile_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.newFile_Button.Image = global::ForgettingCurve.Properties.Resources.Icon;
             this.newFile_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.newFile_Button.Location = new System.Drawing.Point(33, 334);
@@ -220,7 +226,7 @@
             // 
             this.share_Button.FlatAppearance.BorderSize = 0;
             this.share_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.share_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.share_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.share_Button.Image = global::ForgettingCurve.Properties.Resources.Share;
             this.share_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.share_Button.Location = new System.Drawing.Point(33, 442);
@@ -237,7 +243,7 @@
             // 
             this.FileOpen_Button.FlatAppearance.BorderSize = 0;
             this.FileOpen_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.FileOpen_Button.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold);
+            this.FileOpen_Button.Font = new System.Drawing.Font("맑은 고딕", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
             this.FileOpen_Button.Image = ((System.Drawing.Image)(resources.GetObject("FileOpen_Button.Image")));
             this.FileOpen_Button.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.FileOpen_Button.Location = new System.Drawing.Point(33, 388);
@@ -250,22 +256,6 @@
             this.FileOpen_Button.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.FileOpen_Button.UseVisualStyleBackColor = true;
             // 
-            // close_Button
-            // 
-            this.close_Button.FlatAppearance.BorderSize = 0;
-            this.close_Button.FlatAppearance.MouseDownBackColor = System.Drawing.Color.Red;
-            this.close_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.LightCoral;
-            this.close_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.close_Button.Font = new System.Drawing.Font("Microsoft YaHei UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.close_Button.ForeColor = System.Drawing.SystemColors.ActiveCaptionText;
-            this.close_Button.Location = new System.Drawing.Point(1734, 0);
-            this.close_Button.Name = "close_Button";
-            this.close_Button.Size = new System.Drawing.Size(71, 38);
-            this.close_Button.TabIndex = 15;
-            this.close_Button.Text = "X";
-            this.close_Button.UseVisualStyleBackColor = true;
-            this.close_Button.Click += new System.EventHandler(this.close_Button_Click);
-            // 
             // setting_Button
             // 
             this.setting_Button.BackColor = System.Drawing.Color.Silver;
@@ -273,12 +263,91 @@
             this.setting_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.setting_Button.Font = new System.Drawing.Font("굴림", 8F);
             this.setting_Button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
-            this.setting_Button.Location = new System.Drawing.Point(1689, 52);
+            this.setting_Button.Location = new System.Drawing.Point(1684, 96);
             this.setting_Button.Name = "setting_Button";
             this.setting_Button.Size = new System.Drawing.Size(50, 50);
             this.setting_Button.TabIndex = 16;
             this.setting_Button.Text = "설정";
             this.setting_Button.UseVisualStyleBackColor = false;
+            // 
+            // windows_panel
+            // 
+            this.windows_panel.BackColor = System.Drawing.SystemColors.Highlight;
+            this.windows_panel.Controls.Add(this.label1);
+            this.windows_panel.Controls.Add(this.hide_button);
+            this.windows_panel.Controls.Add(this.windows_Button);
+            this.windows_panel.Controls.Add(this.close_Button);
+            this.windows_panel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.windows_panel.Location = new System.Drawing.Point(0, 0);
+            this.windows_panel.Margin = new System.Windows.Forms.Padding(0);
+            this.windows_panel.Name = "windows_panel";
+            this.windows_panel.Size = new System.Drawing.Size(1806, 69);
+            this.windows_panel.TabIndex = 17;
+            this.windows_panel.MouseDown += new System.Windows.Forms.MouseEventHandler(this.windows_panel_MouseDown);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("맑은 고딕", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(129)));
+            this.label1.ForeColor = System.Drawing.SystemColors.ControlLightLight;
+            this.label1.Location = new System.Drawing.Point(19, 20);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(114, 31);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "망각 곡선";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // hide_button
+            // 
+            this.hide_button.Dock = System.Windows.Forms.DockStyle.Right;
+            this.hide_button.FlatAppearance.BorderSize = 0;
+            this.hide_button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.CornflowerBlue;
+            this.hide_button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.hide_button.Font = new System.Drawing.Font("Webdings", 12F);
+            this.hide_button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
+            this.hide_button.Location = new System.Drawing.Point(1593, 0);
+            this.hide_button.Margin = new System.Windows.Forms.Padding(0);
+            this.hide_button.Name = "hide_button";
+            this.hide_button.Size = new System.Drawing.Size(71, 69);
+            this.hide_button.TabIndex = 2;
+            this.hide_button.Text = "0";
+            this.hide_button.UseVisualStyleBackColor = true;
+            this.hide_button.Click += new System.EventHandler(this.hide_button_Click);
+            // 
+            // windows_Button
+            // 
+            this.windows_Button.Dock = System.Windows.Forms.DockStyle.Right;
+            this.windows_Button.FlatAppearance.BorderSize = 0;
+            this.windows_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.CornflowerBlue;
+            this.windows_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.windows_Button.Font = new System.Drawing.Font("Webdings", 12F);
+            this.windows_Button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
+            this.windows_Button.Location = new System.Drawing.Point(1664, 0);
+            this.windows_Button.Margin = new System.Windows.Forms.Padding(0);
+            this.windows_Button.Name = "windows_Button";
+            this.windows_Button.Size = new System.Drawing.Size(71, 69);
+            this.windows_Button.TabIndex = 1;
+            this.windows_Button.Text = "1";
+            this.windows_Button.UseVisualStyleBackColor = true;
+            this.windows_Button.Click += new System.EventHandler(this.windows_Button_Click);
+            // 
+            // close_Button
+            // 
+            this.close_Button.Dock = System.Windows.Forms.DockStyle.Right;
+            this.close_Button.FlatAppearance.BorderSize = 0;
+            this.close_Button.FlatAppearance.MouseOverBackColor = System.Drawing.Color.IndianRed;
+            this.close_Button.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.close_Button.Font = new System.Drawing.Font("Webdings", 12F);
+            this.close_Button.ForeColor = System.Drawing.SystemColors.ButtonHighlight;
+            this.close_Button.Location = new System.Drawing.Point(1735, 0);
+            this.close_Button.Margin = new System.Windows.Forms.Padding(0);
+            this.close_Button.Name = "close_Button";
+            this.close_Button.Size = new System.Drawing.Size(71, 69);
+            this.close_Button.TabIndex = 0;
+            this.close_Button.Text = "r";
+            this.close_Button.UseVisualStyleBackColor = true;
+            this.close_Button.Click += new System.EventHandler(this.close_Button_Click);
             // 
             // MainForm
             // 
@@ -287,8 +356,8 @@
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.BackColor = System.Drawing.Color.White;
             this.ClientSize = new System.Drawing.Size(1806, 1060);
+            this.Controls.Add(this.windows_panel);
             this.Controls.Add(this.setting_Button);
-            this.Controls.Add(this.close_Button);
             this.Controls.Add(this.Panel);
             this.Controls.Add(this.user_Button);
             this.Controls.Add(this.main_Logo);
@@ -299,6 +368,8 @@
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.Panel.ResumeLayout(false);
             this.Panel.PerformLayout();
+            this.windows_panel.ResumeLayout(false);
+            this.windows_panel.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -320,7 +391,11 @@
         private System.Windows.Forms.Button FileOpen_Button;
         private System.Windows.Forms.Label recentFile_Text;
         private System.Windows.Forms.Panel recentFIle_Panel;
-        private System.Windows.Forms.Button close_Button;
         private System.Windows.Forms.Button setting_Button;
+        private System.Windows.Forms.Panel windows_panel;
+        private System.Windows.Forms.Button hide_button;
+        private System.Windows.Forms.Button windows_Button;
+        private System.Windows.Forms.Button close_Button;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/ForgettingCurve/MainForm.cs
+++ b/ForgettingCurve/MainForm.cs
@@ -2,21 +2,42 @@
 using ForgettingCurve.Control.FileEditor;
 using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace ForgettingCurve {
     public partial class MainForm : Form {
 
+        #region ◆ 윈도우 dll 선언 부분 (Sub 부분)
+        /* Form의 설정 중 FormBorderStyle(폼 테두리 스타일)을 None(없음)으로 설정 시 폼의 테두리가 없어져서
+         * 드래그를 통해 폼의 위치를 옮길 수가 없는데 윈도우의 내장 dll파일을 이용하여 테두리가 없어도
+         * 폼의 아무 부분을 클릭하고 드래그하면 이동 시킬 수 있는 형식으로 만들기 위해
+         * dll을 Import한 SendMessage()와 ReleaseCapture()를 선언함
+         * [요약] => 테두리가 없어진 윈도우 폼을 드래그로 이동시키기 위해 선언됨 */
+        [DllImport("user32.dll")] public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
+        [DllImport("user32.dll")] public static extern bool ReleaseCapture();
+
+        // Windows의 메시지 상수
+        private const int WM_NCLBUTTONDOWN = 0xA1;
+        private const int HT_CAPTION = 0x2;
+        private void windows_panel_MouseDown(object sender, MouseEventArgs e) {
+            ReleaseCapture();
+            SendMessage(this.Handle, WM_NCLBUTTONDOWN, HT_CAPTION, 0);
+        }
+        #endregion
 
         TextEditor_Form textEditor = new TextEditor_Form();
         CalenderControl calenderControl = new CalenderControl();
 
         public MainForm() {
             InitializeComponent();
+            // 윈도우 폼에 그림자를 추가하는 코드
+            (new Core.DropShadow()).ApplyShadows(this);
         }
 
         private void MainForm_Load(object sender, EventArgs e) {
-
+            this.Controls.Add(calenderControl);
+            calenderControl.Visible = false;
         }
 
         private void newFile_Button_Click(object sender, EventArgs e) {
@@ -25,20 +46,49 @@ namespace ForgettingCurve {
             textEditor.Show(); // 비Dialog 방식으로 fileEditor 폼을 오픈
         }
 
+        private void calender_Button_Click(object sender, EventArgs e)
+        {
+            calenderControl.Visible = true;
+            recentFile_Text.Visible = false;
+            recentFIle_Panel.Visible = false;
+            //if (!calenderControl.IsDisposed)
+            //    calenderControl.Dispose();
+            calenderControl.Location = new Point(300, 200);
+            calenderControl.BringToFront();
+        }
+
+        #region # 윈도우 창 버튼 코드 영역
         private void close_Button_Click(object sender, EventArgs e) {
             this.Close();
         }
 
-        private void calender_Button_Click(object sender, EventArgs e)
-        {
-            recentFile_Text.Visible = false;
-            recentFIle_Panel.Visible = false;
-            if (!calenderControl.IsDisposed)
-                calenderControl.Dispose();
-            calenderControl = new CalenderControl();
-            this.Controls.Add(calenderControl);
-            calenderControl.Location = new Point(300, 200);
-            calenderControl.BringToFront();
+        private bool normalSize = true;
+
+        private void windows_Button_Click(object sender, EventArgs e) {
+            if (normalSize) {
+                this.WindowState = FormWindowState.Maximized;
+                windows_Button.Text = "2";
+            }
+
+            else {
+                this.WindowState = FormWindowState.Normal;
+                windows_Button.Text = "1";
+            }
+
+            normalSize = !normalSize;
+        }
+
+        private void hide_button_Click(object sender, EventArgs e) {
+            this.WindowState = FormWindowState.Minimized;
+        }
+
+
+        #endregion
+
+        private void home_Button_Click(object sender, EventArgs e) {
+            calenderControl.Visible = false;
+            recentFile_Text.Visible = true;
+            recentFIle_Panel.Visible = true;
         }
     }
 }

--- a/ForgettingCurve/MainForm.resx
+++ b/ForgettingCurve/MainForm.resx
@@ -121,10 +121,11 @@
   <data name="FileOpen_Button.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABgAAAAaCAYAAACtv5zzAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAJ5JREFUSEvFkFEOgCAMQ3cS739LDApq2kImGZnJ82Pt2qmVUqxiZvW1RNt/np55
-        zSMK7sw3dFqAhhmeEjKjYQYWqH0yo0HR//N3Z1QiC/Cq4bLQyYPm2SItC508aP6Kf1EZUsSLPGBGbsEq
-        KkOKeJ0HzMgtWEVlSBGv84AZuQVezOzojDKWClro3i/YXqBQGSRGkFOwCxpEQ4NoaBDNCRAAMY7WEWWC
-        AAAAAElFTkSuQmCC
+        DAAACwwBP0AiyAAAANBJREFUSEu1jAESgyAMBPuS/v+XVKmbxHDixFJmtl25416ttc529p9HHO/tsNnv
+        TcKDJ7CTcbkpKngze+syKV3Bm8jQMbkoKHr5+29vcL7BJYS4gv6sd+qYhBBX0J/1Th0TEVZRGzLEK+QN
+        cBHFCnkDXERYRW3IEK+QN8BFFCvkDXARYRW1IUO8Qt4AF1GskDfARYR3bOcNx/ewEctDeMV29tHeh+Pe
+        HFxEOIN+fBcdXERYRW0M4QrY7LsmqfQLbPbd+PEP5OVK5OVK5OU62usDEAAxjtI9E2gAAAAASUVORK5C
+        YII=
 </value>
   </data>
 </root>


### PR DESCRIPTION
## Feat : Form에 그림자 및 부드러운 테두리 추가 및 Control_File 버튼 구현
- DropShadowWindows.cs 파일로 Form에 그림자, 부드러운 테두리 추가
- CalederControls의 Visible을 true, false하여 필요 없는 객체 선언을 줄임
- 메인 폼의 HOME 버튼 기눙 구현
- TextEditor 내의 Control_File 버튼들 기능 구현
- 미사용 using 문 삭제